### PR TITLE
feat: add headers argument and a custom user-agents for http requests

### DIFF
--- a/docling_core/utils/file.py
+++ b/docling_core/utils/file.py
@@ -5,7 +5,6 @@
 
 """File-related utilities."""
 
-import random
 import tempfile
 from pathlib import Path
 from typing import Union
@@ -14,43 +13,8 @@ import requests
 from pydantic import AnyHttpUrl, TypeAdapter, ValidationError
 
 
-def get_random_headers(custom_headers: list[dict] = []):
-    """Pick or create a random request header."""
-    if len(custom_headers) > 0:
-        return random.choice(custom_headers)
-
-    # List of 10 randomly picked User-Agent headers
-    user_agents = [
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
-        "(KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36",
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
-        "(KHTML, like Gecko) Chrome/88.0.4324.150 Safari/537.36",
-        "Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 "
-        "(KHTML, like Gecko) Version/14.0.1 Mobile/15E148 Safari/604.1",
-        "Mozilla/5.0 (Linux; Android 10; SM-G973F) AppleWebKit/537.36 "
-        "(KHTML, like Gecko) Chrome/91.0.4472.114 Mobile Safari/537.36",
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
-        "(KHTML, like Gecko) Chrome/90.0.4430.85 Safari/537.36 Edg/90.0.818.49",
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 "
-        "(KHTML, like Gecko) Version/14.0.2 Safari/605.1.15",
-        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
-        "(KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36 OPR/74.0.3911.160",
-        "Mozilla/5.0 (Android 11; Mobile; rv:86.0) Gecko/86.0 Firefox/86.0",
-        "Mozilla/5.0 (X11; CrOS x86_64 13816.64.0) AppleWebKit/537.36 "
-        "(KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36",
-        "Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) like Gecko",
-    ]
-
-    # Randomly select a User-Agent
-    random_user_agent = random.choice(user_agents)
-
-    # Define the headers with the random User-Agent
-    headers = {"User-Agent": random_user_agent}
-    return headers
-
-
 def resolve_file_source(
-    source: Union[Path, AnyHttpUrl, str], custom_headers: list[dict] = []
+    source: Union[Path, AnyHttpUrl, str], custom_headers: dict[str, str] = {}
 ) -> Path:
     """Resolves the source (URL, path) of a file to a local file path.
 
@@ -67,8 +31,11 @@ def resolve_file_source(
     """
     try:
         http_url: AnyHttpUrl = TypeAdapter(AnyHttpUrl).validate_python(source)
-        headers = get_random_headers(custom_headers)
-        res = requests.get(http_url, stream=True, headers=headers)
+
+        if "User-Agent" not in custom_headers:
+            custom_headers["User-Agent"] = "docling/v2"
+
+        res = requests.get(http_url, stream=True, headers=custom_headers)
         res.raise_for_status()
         fname = None
         # try to get filename from response header

--- a/docling_core/utils/file.py
+++ b/docling_core/utils/file.py
@@ -5,6 +5,7 @@
 
 """File-related utilities."""
 
+import random
 import tempfile
 from pathlib import Path
 from typing import Union
@@ -13,7 +14,44 @@ import requests
 from pydantic import AnyHttpUrl, TypeAdapter, ValidationError
 
 
-def resolve_file_source(source: Union[Path, AnyHttpUrl, str]) -> Path:
+def get_random_headers(custom_headers: list[dict] = []):
+    """Pick or create a random request header."""
+    if len(custom_headers) > 0:
+        return random.choice(custom_headers)
+
+    # List of 10 randomly picked User-Agent headers
+    user_agents = [
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36",
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/88.0.4324.150 Safari/537.36",
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 "
+        "(KHTML, like Gecko) Version/14.0.1 Mobile/15E148 Safari/604.1",
+        "Mozilla/5.0 (Linux; Android 10; SM-G973F) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/91.0.4472.114 Mobile Safari/537.36",
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/90.0.4430.85 Safari/537.36 Edg/90.0.818.49",
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 "
+        "(KHTML, like Gecko) Version/14.0.2 Safari/605.1.15",
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36 OPR/74.0.3911.160",
+        "Mozilla/5.0 (Android 11; Mobile; rv:86.0) Gecko/86.0 Firefox/86.0",
+        "Mozilla/5.0 (X11; CrOS x86_64 13816.64.0) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36",
+        "Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) like Gecko",
+    ]
+
+    # Randomly select a User-Agent
+    random_user_agent = random.choice(user_agents)
+
+    # Define the headers with the random User-Agent
+    headers = {"User-Agent": random_user_agent}
+    return headers
+
+
+def resolve_file_source(
+    source: Union[Path, AnyHttpUrl, str], custom_headers: list[dict] = []
+) -> Path:
     """Resolves the source (URL, path) of a file to a local file path.
 
     If a URL is provided, the content is first downloaded to a temporary local file.
@@ -29,7 +67,8 @@ def resolve_file_source(source: Union[Path, AnyHttpUrl, str]) -> Path:
     """
     try:
         http_url: AnyHttpUrl = TypeAdapter(AnyHttpUrl).validate_python(source)
-        res = requests.get(http_url, stream=True)
+        headers = get_random_headers(custom_headers)
+        res = requests.get(http_url, stream=True, headers=headers)
         res.raise_for_status()
         fname = None
         # try to get filename from response header

--- a/docling_core/utils/file.py
+++ b/docling_core/utils/file.py
@@ -8,14 +8,14 @@
 import importlib
 import tempfile
 from pathlib import Path
-from typing import Union
+from typing import Dict, Optional, Union
 
 import requests
 from pydantic import AnyHttpUrl, TypeAdapter, ValidationError
 
 
 def resolve_file_source(
-    source: Union[Path, AnyHttpUrl, str], headers: dict[str, str] = {}
+    source: Union[Path, AnyHttpUrl, str], headers: Optional[Dict[str, str]] = None
 ) -> Path:
     """Resolves the source (URL, path) of a file to a local file path.
 
@@ -34,12 +34,14 @@ def resolve_file_source(
         http_url: AnyHttpUrl = TypeAdapter(AnyHttpUrl).validate_python(source)
 
         # make all header keys lower case
-        req_headers = {k.lower(): v for k, v in headers.items()}
+        _headers = headers or {}
+        req_headers = {k.lower(): v for k, v in _headers.items()}
         # add user-agent is not set
         if "user-agent" not in req_headers:
             agent_name = f"docling-core/{importlib.metadata.version('docling-core')}"
             req_headers["user-agent"] = agent_name
 
+        # fetch the page
         res = requests.get(http_url, stream=True, headers=req_headers)
         res.raise_for_status()
         fname = None

--- a/docling_core/utils/file.py
+++ b/docling_core/utils/file.py
@@ -5,6 +5,7 @@
 
 """File-related utilities."""
 
+import importlib
 import tempfile
 from pathlib import Path
 from typing import Union
@@ -14,7 +15,7 @@ from pydantic import AnyHttpUrl, TypeAdapter, ValidationError
 
 
 def resolve_file_source(
-    source: Union[Path, AnyHttpUrl, str], custom_headers: dict[str, str] = {}
+    source: Union[Path, AnyHttpUrl, str], headers: dict[str, str] = {}
 ) -> Path:
     """Resolves the source (URL, path) of a file to a local file path.
 
@@ -32,10 +33,14 @@ def resolve_file_source(
     try:
         http_url: AnyHttpUrl = TypeAdapter(AnyHttpUrl).validate_python(source)
 
-        if "User-Agent" not in custom_headers:
-            custom_headers["User-Agent"] = "docling/v2"
+        # make all header keys lower case
+        req_headers = {k.lower(): v for k, v in headers.items()}
+        # add user-agent is not set
+        if "user-agent" not in req_headers:
+            agent_name = f"docling-core/{importlib.metadata.version('docling-core')}"
+            req_headers["user-agent"] = agent_name
 
-        res = requests.get(http_url, stream=True, headers=custom_headers)
+        res = requests.get(http_url, stream=True, headers=req_headers)
         res.raise_for_status()
         fname = None
         # try to get filename from response header


### PR DESCRIPTION
Currently, when we use the docling cli, we often can not pull the html pages, because we do not have compliant requests with user-agents. This PR fixes that.