### PR TITLE
Fix/fix output in md tables

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -591,7 +591,13 @@ class TableItem(FloatingItem):
         for row in self.data.grid:
             tmp = []
             for col in row:
-                tmp.append(col.text)
+
+                # make sure that md tables are not broken
+                # due to newline chars in the text
+                text = col.text
+                text = text.replace("\n", "")                
+                tmp.append(text)
+                
             table.append(tmp)
 
         md_table = ""

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -595,9 +595,9 @@ class TableItem(FloatingItem):
                 # make sure that md tables are not broken
                 # due to newline chars in the text
                 text = col.text
-                text = text.replace("\n", "")                
+                text = text.replace("\n", "")
                 tmp.append(text)
-                
+
             table.append(tmp)
 
         md_table = ""


### PR DESCRIPTION
Avoid broken tables, eg,

input (https://en.wikipedia.org/wiki/IBM):

<img width="359" alt="Screenshot 2024-10-24 at 10 49 35" src="https://github.com/user-attachments/assets/42933911-54b6-4f64-a3c5-79352dd908c2">

current output:

```
| Year
         |      Revenue
(US$ bn)
 |      Net income
(US$ bn)
 | Employees
         |
|---------|------|------|---------|
| 2014    | 92.7 | 12   | 379,592 |
| 2015    | 81.7 | 13.1 | 377,757 |
| 2016    | 79.9 | 11.8 | 380,300 |
| 2017    | 79.1 |  5.7 | 366,600 |
| 2018    | 79.5 |  8.7 | 350,600 |
| 2019    | 77.1 |  9.4 | 352,600 |
| 2020    | 73.6 |  5.5 | 345,900 |
| 2021[a] | 57.3 |  5.7 | 282,100 |
| 2022    | 60.5 |  1.6 | 288,300 |
| 2023    | 61.8 |  7.5 | 282,200 |
```

desired output:

```
| Year |  Revenue (US$ bn)|  Net income (US$ bn) | Employees |
|---------|------|------|---------|
| 2014    | 92.7 | 12   | 379,592 |
| 2015    | 81.7 | 13.1 | 377,757 |
| 2016    | 79.9 | 11.8 | 380,300 |
| 2017    | 79.1 |  5.7 | 366,600 |
| 2018    | 79.5 |  8.7 | 350,600 |
| 2019    | 77.1 |  9.4 | 352,600 |
| 2020    | 73.6 |  5.5 | 345,900 |
| 2021[a] | 57.3 |  5.7 | 282,100 |
| 2022    | 60.5 |  1.6 | 288,300 |
| 2023    | 61.8 |  7.5 | 282,200 |
```
