### PR TITLE
feat: simple method to load DoclingDocument from .json files

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -1,8 +1,6 @@
 """Models for the Docling Document data type."""
 
 import base64
-import copy
-import hashlib
 import json
 import mimetypes
 import os
@@ -1738,112 +1736,20 @@ class DoclingDocument(BaseModel):
             elif isinstance(item, DocItem):
                 print(" " * level, f"{ix}: {item.label.value}")
 
-    def export_to_element_tree(self) -> str:
-        """Export_to_element_tree."""
-        texts = []
-        for ix, (item, level) in enumerate(self.iterate_items(with_groups=True)):
-            if isinstance(item, GroupItem):
-                texts.append(
-                    " " * level + f"{ix}: {item.label.value} with name={item.name}"
-                )
-            elif isinstance(item, DocItem):
-                texts.append(" " * level + f"{ix}: {item.label.value}")
+    def export_to_dict(self) -> Dict:
+        """export_to_dict."""
+        return self.model_dump(mode="json", by_alias=True, exclude_none=True)
 
-        return "\n".join(texts)
-
-    def save_as_json(
-        self,
-        filename: Path,
-        artifacts_dir: Optional[Path] = None,
-        image_mode: ImageRefMode = ImageRefMode.EMBEDDED,
-        indent: int = 2,
-    ):
-        """Save as json."""
-        artifacts_dir, reference_path = self._get_output_paths(filename, artifacts_dir)
-
-        if image_mode == ImageRefMode.REFERENCED:
-            os.makedirs(artifacts_dir, exist_ok=True)
-
-        new_doc = self._make_copy_with_refmode(
-            artifacts_dir, image_mode, reference_path=reference_path
-        )
-
-        out = new_doc.export_to_dict()
-        with open(filename, "w") as fw:
-            json.dump(out, fw, indent=indent)
-
-    def save_as_yaml(
-        self,
-        filename: Path,
-        artifacts_dir: Optional[Path] = None,
-        image_mode: ImageRefMode = ImageRefMode.EMBEDDED,
-        default_flow_style: bool = False,
-    ):
-        """Save as yaml."""
-        artifacts_dir, reference_path = self._get_output_paths(filename, artifacts_dir)
-
-        if image_mode == ImageRefMode.REFERENCED:
-            os.makedirs(artifacts_dir, exist_ok=True)
-
-        new_doc = self._make_copy_with_refmode(
-            artifacts_dir, image_mode, reference_path=reference_path
-        )
-
-        out = new_doc.export_to_dict()
-        with open(filename, "w") as fw:
-            yaml.dump(out, fw, default_flow_style=default_flow_style)
-
-    def export_to_dict(
-        self,
-        mode: str = "json",
-        by_alias: bool = True,
-        exclude_none: bool = True,
-    ) -> Dict:
-        """Export to dict."""
-        out = self.model_dump(mode=mode, by_alias=by_alias, exclude_none=exclude_none)
-
-        return out
-
-    def save_as_markdown(
-        self,
-        filename: Path,
-        artifacts_dir: Optional[Path] = None,
-        delim: str = "\n",
-        from_element: int = 0,
-        to_element: int = sys.maxsize,
-        labels: set[DocItemLabel] = DEFAULT_EXPORT_LABELS,
-        strict_text: bool = False,
-        image_placeholder: str = "<!-- image -->",
-        image_mode: ImageRefMode = ImageRefMode.PLACEHOLDER,
-        indent: int = 4,
-        text_width: int = -1,
-        page_no: Optional[int] = None,
-    ):
-        """Save to markdown."""
-        artifacts_dir, reference_path = self._get_output_paths(filename, artifacts_dir)
-
-        if image_mode == ImageRefMode.REFERENCED:
-            os.makedirs(artifacts_dir, exist_ok=True)
-
-        new_doc = self._make_copy_with_refmode(
-            artifacts_dir, image_mode, reference_path=reference_path
-        )
-
-        md_out = new_doc.export_to_markdown(
-            delim=delim,
-            from_element=from_element,
-            to_element=to_element,
-            labels=labels,
-            strict_text=strict_text,
-            image_placeholder=image_placeholder,
-            image_mode=image_mode,
-            indent=indent,
-            text_width=text_width,
-            page_no=page_no,
-        )
-
-        with open(filename, "w") as fw:
-            fw.write(md_out)
+    def save_to_json_file(self, document_json_path, indent: int=4) -> int:
+        """export_to_json."""
+        with open(document_json_path, 'w') as f:
+            return f.write(self.model_dump_json(indent=indent))
+    
+    @classmethod
+    def load_from_json_file(cls, document_json_path):
+        """load_from_json."""
+        with open(document_json_path, 'r') as f:
+            return cls(**json.load(f))
 
     def export_to_markdown(  # noqa: C901
         self,

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -1741,11 +1741,13 @@ class DoclingDocument(BaseModel):
         """export_to_dict."""
         return self.model_dump(mode="json", by_alias=True, exclude_none=True)
 
-    def save_to_json_file(self, path: Union[str, Path], indent: int=4) -> int:
+    def save_to_json_file(self, path: Union[str, Path], indent: int=4):
         """
         export_to_json.
         :param path: The file path to write this DoclingDocument to as .json.
         :type delim: Union[str, Path]
+        :param indent: The number of spaces to use for indentation in the .json file (Default value = 4).
+        :type delim: int
         """
         with open(path, 'w') as f:
             json.dump(self.export_to_dict(), f, indent=indent)
@@ -1762,7 +1764,6 @@ class DoclingDocument(BaseModel):
         
         """
         with open(path, 'r') as f:
-            # return cls(**json.load(f))
             return cls.model_validate_json(f.read())
 
     def export_to_markdown(  # noqa: C901

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -3,14 +3,13 @@
 import base64
 import json
 import mimetypes
-import os
-from pathlib import Path
 import re
 import sys
 import textwrap
 import typing
 import warnings
 from io import BytesIO
+from pathlib import Path
 from pathlib import Path
 from typing import Any, Dict, Final, List, Literal, Optional, Tuple, Union
 from urllib.parse import unquote
@@ -1741,29 +1740,30 @@ class DoclingDocument(BaseModel):
         """export_to_dict."""
         return self.model_dump(mode="json", by_alias=True, exclude_none=True)
 
-    def save_to_json_file(self, path: Union[str, Path], indent: int=4):
+    def save_to_json_file(self, path: Union[str, Path], indent: int = 4):
         """
         export_to_json.
         :param path: The file path to write this DoclingDocument to as .json.
         :type delim: Union[str, Path]
-        :param indent: The number of spaces to use for indentation in the .json file (Default value = 4).
+        :param indent: The number of spaces to use for indentation in the .json
+            file (Default value = 4).
         :type delim: int
         """
-        with open(path, 'w') as f:
+        with open(path, "w") as f:
             json.dump(self.export_to_dict(), f, indent=indent)
-    
+
     @classmethod
     def load_from_json_file(cls, path: Union[str, Path]) -> "DoclingDocument":
         """
         load_from_json.
         :param path: The file path to load a saved DoclingDocument from a .json.
         :type delim: Union[str, Path]
-        
+
         :returns: The loaded DoclingDocument.
         :rtype: DoclingDocument
-        
+
         """
-        with open(path, 'r') as f:
+        with open(path, "r") as f:
             return cls.model_validate_json(f.read())
 
     def export_to_markdown(  # noqa: C901
@@ -1785,26 +1785,28 @@ class DoclingDocument(BaseModel):
         from_element and to_element; defaulting to the whole document.
 
         :param delim: Delimiter to use when concatenating the various
-                Markdown parts. Defaults to "\n\n".
-        :type delim: str
+                Markdown parts. (Default value = "\n").
+        :type delim: str = "\n"
         :param from_element: Body slicing start index (inclusive).
-                Defaults to 0.
-        :type from_element: int
+                (Default value = 0).
+        :type from_element: int = 0
         :param to_element: Body slicing stop index
-                (exclusive). Defaults to 0maxint.
-        :type to_element: int
-        :param delim: str:  (Default value = "\n\n")
-        :param labels: set[DocItemLabel]
-        :param "subtitle-level-1":
-        :param "paragraph":
-        :param "caption":
-        :param "table":
-        :param "Text":
-        :param "text":
-        :param strict_text: bool:  (Default value = False)
-        :param image_placeholder str:  (Default value = "<!-- image -->")
-            the placeholder to include to position images in the markdown.
-        :param indent: int (default=4): indent of the nested lists
+                (exclusive). (Default value = maxint).
+        :type to_element: int = sys.maxsize
+        :param labels: The set of document labels to include in the export.
+        :type labels: set[DocItemLabel] = DEFAULT_EXPORT_LABELS
+        :param strict_text: bool: Whether to only include the text content
+            of the document. (Default value = False).
+        :type strict_text: bool = False
+        :param image_placeholder: The placeholder to include to position
+            images in the markdown. (Default value = "\<!-- image --\>").
+        :type image_placeholder: str = "<!-- image -->"
+        :param image_mode: The mode to use for including images in the
+            markdown. (Default value = ImageRefMode.PLACEHOLDER).
+        :type image_mode: ImageRefMode = ImageRefMode.PLACEHOLDER
+        :param indent: The indent in spaces of the nested lists.
+            (Default value = 4).
+        :type indent: int = 4
         :returns: The exported Markdown representation.
         :rtype: str
         """

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -4,6 +4,7 @@ import base64
 import json
 import mimetypes
 import os
+from pathlib import Path
 import re
 import sys
 import textwrap
@@ -1740,16 +1741,29 @@ class DoclingDocument(BaseModel):
         """export_to_dict."""
         return self.model_dump(mode="json", by_alias=True, exclude_none=True)
 
-    def save_to_json_file(self, document_json_path, indent: int=4) -> int:
-        """export_to_json."""
-        with open(document_json_path, 'w') as f:
-            return f.write(self.model_dump_json(indent=indent))
+    def save_to_json_file(self, path: Union[str, Path], indent: int=4) -> int:
+        """
+        export_to_json.
+        :param path: The file path to write this DoclingDocument to as .json.
+        :type delim: Union[str, Path]
+        """
+        with open(path, 'w') as f:
+            json.dump(self.export_to_dict(), f, indent=indent)
     
     @classmethod
-    def load_from_json_file(cls, document_json_path):
-        """load_from_json."""
-        with open(document_json_path, 'r') as f:
-            return cls(**json.load(f))
+    def load_from_json_file(cls, path: Union[str, Path]) -> "DoclingDocument":
+        """
+        load_from_json.
+        :param path: The file path to load a saved DoclingDocument from a .json.
+        :type delim: Union[str, Path]
+        
+        :returns: The loaded DoclingDocument.
+        :rtype: DoclingDocument
+        
+        """
+        with open(path, 'r') as f:
+            # return cls(**json.load(f))
+            return cls.model_validate_json(f.read())
 
     def export_to_markdown(  # noqa: C901
         self,

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -1775,6 +1775,7 @@ class DoclingDocument(BaseModel):
     @classmethod
     def load_from_json(cls, filename: Path) -> "DoclingDocument":
         """load_from_json.
+
         :param filename: The filename to load a saved DoclingDocument from a .json.
         :type filename: Path
 
@@ -1783,7 +1784,7 @@ class DoclingDocument(BaseModel):
 
         """
         with open(filename, "r") as f:
-            return cls.model_validate_json(f.read())
+            return cls.model_validate(json.loads(f.read()))
 
     def save_as_yaml(
         self,


### PR DESCRIPTION
I wrote utility functions in a script to save and load `DoclingDocument` objects to file:
```python
def save_document(document: DoclingDocument, document_json_path: Union[str, Path]):
        with open(document_json_path, 'w') as f:
            f.write(document.model_dump_json(indent=4))

def load_document(document_json_path: Union[str, Path]) -> DoclingDocument:
    assert os.path.exists(document_json_path), f"Document JSON file not found: {document_json_path}"
    with open(document_json_path, 'r') as f:
        json_data = json.load(f)
    return DoclingDocument(**json_data)
```

Which saved a lot of time when testing workflows with very long, complex documents. Not needing to reprocess the documents each time was very useful, but I did not see a builtin tool to save to a file directly (like `pandas.DataFrame.to_csv`), so I added the following:
```python
class DoclingDocument(BaseModel):
...
    def save_to_json_file(self, document_json_path, indent: int=4) -> int:
        """export_to_json."""
        with open(document_json_path, 'w') as f:
            return f.write(self.model_dump_json(indent=indent))
    
    @classmethod
    def load_from_json_file(cls, document_json_path):
        """load_from_json."""
        with open(document_json_path, 'r') as f:
            return cls(**json.load(f))
...
```


I think adding some simple built-in functions may help save people the time in figuring out the best way to save and load processed documents!