### PR TITLE
feat: extend source resolution with streams and workdir

### DIFF
--- a/docling_core/types/io/__init__.py
+++ b/docling_core/types/io/__init__.py
@@ -1,0 +1,19 @@
+#
+# Copyright IBM Corp. 2024 - 2024
+# SPDX-License-Identifier: MIT
+#
+
+"""Models for io."""
+
+from io import BytesIO
+
+from pydantic import BaseModel, ConfigDict
+
+
+class DocumentStream(BaseModel):
+    """Wrapper class for a bytes stream with a filename."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    name: str
+    stream: BytesIO

--- a/docling_core/utils/file.py
+++ b/docling_core/utils/file.py
@@ -12,17 +12,10 @@ from pathlib import Path
 from typing import Dict, Optional, Union
 
 import requests
-from pydantic import AnyHttpUrl, BaseModel, ConfigDict, TypeAdapter, ValidationError
+from pydantic import AnyHttpUrl, TypeAdapter, ValidationError
 from typing_extensions import deprecated
 
-
-class DocumentStream(BaseModel):
-    """Wrapper class for a bytes stream with a filename."""
-
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    name: str
-    stream: BytesIO
+from docling_core.types.io import DocumentStream
 
 
 def resolve_remote_filename(

--- a/docling_core/utils/file.py
+++ b/docling_core/utils/file.py
@@ -7,28 +7,38 @@
 
 import importlib
 import tempfile
+from io import BytesIO
 from pathlib import Path
 from typing import Dict, Optional, Union
 
 import requests
-from pydantic import AnyHttpUrl, TypeAdapter, ValidationError
+from pydantic import AnyHttpUrl, BaseModel, ConfigDict, TypeAdapter, ValidationError
 
 
-def resolve_file_source(
+class DocumentStream(BaseModel):
+    """Wrapper class for a bytes stream with a filename."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    name: str
+    stream: BytesIO
+
+
+def read_file_source(
     source: Union[Path, AnyHttpUrl, str], headers: Optional[Dict[str, str]] = None
-) -> Path:
-    """Resolves the source (URL, path) of a file to a local file path.
-
-    If a URL is provided, the content is first downloaded to a temporary local file.
+) -> DocumentStream:
+    """Resolves the source (URL, path) of a file to a binary stream.
 
     Args:
         source (Path | AnyHttpUrl | str): The file input source. Can be a path or URL.
+        headers (Dict | None): Optional set of headers to use for fetching
+            the remote URL.
 
     Raises:
         ValueError: If source is of unexpected type.
 
     Returns:
-        Path: The local file path.
+        DocumentStream: The resolved file loaded as a stream.
     """
     try:
         http_url: AnyHttpUrl = TypeAdapter(AnyHttpUrl).validate_python(source)
@@ -55,15 +65,55 @@ def resolve_file_source(
         # otherwise, use name from URL:
         if fname is None:
             fname = Path(http_url.path or "").name or "file"
-        local_path = Path(tempfile.mkdtemp()) / fname
-        with open(local_path, "wb") as f:
-            for chunk in res.iter_content(chunk_size=1024):  # using 1-KB chunks
-                f.write(chunk)
+
+        stream = BytesIO(res.content)
+        doc_stream = DocumentStream(name=fname, stream=stream)
     except ValidationError:
         try:
             local_path = TypeAdapter(Path).validate_python(source)
+            stream = BytesIO(local_path.read_bytes())
+            doc_stream = DocumentStream(name=local_path.name, stream=stream)
         except ValidationError:
             raise ValueError(f"Unexpected source type encountered: {type(source)}")
+    return doc_stream
+
+
+def resolve_file_source(
+    source: Union[Path, AnyHttpUrl, str],
+    headers: Optional[Dict[str, str]] = None,
+    workdir: Optional[Path] = None,
+) -> Path:
+    """Resolves the source (URL, path) of a file to a local file path.
+
+    If a URL is provided, the content is first downloaded to a temporary local file.
+
+    Args:
+        source (Path | AnyHttpUrl | str): The file input source. Can be a path or URL.
+        headers (Dict | None): Optional set of headers to use for fetching
+            the remote URL.
+        workdir (Path | None): If set, the work directory where the file will
+            be downloaded, otherwise a temp dir will be used.
+
+    Raises:
+        ValueError: If source is of unexpected type.
+
+    Returns:
+        Path: The local file path.
+    """
+    doc_stream = read_file_source(source=source, headers=headers)
+
+    # use a temporary directory if not specified
+    if workdir is None:
+        workdir = Path(tempfile.mkdtemp())
+
+    # create the parent workdir if it doesn't exist
+    workdir.mkdir(exist_ok=True, parents=True)
+
+    # save result to a local file
+    local_path = workdir / doc_stream.name
+    with local_path.open("wb") as f:
+        f.write(doc_stream.stream.read())
+
     return local_path
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1027,9 +1027,9 @@ files = [
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
     {version = ">=1.22.4", markers = "python_version < \"3.11\""},
     {version = ">=1.23.2", markers = "python_version == \"3.11\""},
+    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -1297,8 +1297,8 @@ files = [
 annotated-types = ">=0.6.0"
 pydantic-core = "2.23.4"
 typing-extensions = [
-    {version = ">=4.12.2", markers = "python_version >= \"3.13\""},
     {version = ">=4.6.1", markers = "python_version < \"3.13\""},
+    {version = ">=4.12.2", markers = "python_version >= \"3.13\""},
 ]
 
 [package.extras]
@@ -2056,4 +2056,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "a294453c3f8281316c145a70a8e705953cb8e45df7f6481dabbf09904cbc456c"
+content-hash = "4f24f28aed5a512ec124dfbd9828790c4310626a78fe7e63b8684575c529e328"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ tabulate = "^0.9.0"
 pandas = "^2.1.4"
 pillow = "^10.3.0"
 pyyaml = ">=5.1,<7.0.0"
+typing-extensions = "^4.12.2"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.4.2"

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -10,7 +10,7 @@ from pydantic import Field
 from requests import Response
 
 from docling_core.utils.alias import AliasModel
-from docling_core.utils.file import read_file_source, resolve_file_source
+from docling_core.utils.file import resolve_source_to_path, resolve_source_to_stream
 
 
 def test_alias_model():
@@ -51,7 +51,7 @@ def test_alias_model():
     assert obj.model_dump_json() != json.dumps(data, separators=(",", ":"))
 
 
-def test_resolve_file_source_url_wout_path(monkeypatch):
+def test_resolve_source_to_path_url_wout_path(monkeypatch):
     expected_str = "foo"
     expected_bytes = bytes(expected_str, "utf-8")
 
@@ -66,13 +66,13 @@ def test_resolve_file_source_url_wout_path(monkeypatch):
         "requests.models.Response.iter_content",
         lambda *args, **kwargs: [expected_bytes],
     )
-    path = resolve_file_source("https://pypi.org")
+    path = resolve_source_to_path("https://pypi.org")
     with open(path) as f:
         text = f.read()
     assert text == expected_str
 
 
-def test_read_file_source_url_wout_path(monkeypatch):
+def test_resolve_source_to_stream_url_wout_path(monkeypatch):
     expected_str = "foo"
     expected_bytes = bytes(expected_str, "utf-8")
 
@@ -87,7 +87,7 @@ def test_read_file_source_url_wout_path(monkeypatch):
         "requests.models.Response.iter_content",
         lambda *args, **kwargs: [expected_bytes],
     )
-    doc_stream = read_file_source("https://pypi.org")
+    doc_stream = resolve_source_to_stream("https://pypi.org")
     assert doc_stream.name == "file"
 
     text = doc_stream.stream.read().decode("utf8")


### PR DESCRIPTION
Extension to the resolution of file source
1. Add `workdir` to `resolve_file_source()` by keeping it backwards compatible. 
2. Add a new version `read_file_source()` which returns a document stream to completely avoid writing files

This will be used in Docling to avoid having leftover files in the temporary dir.