### PR TITLE
fix: allow all url types in referenced exports

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -864,14 +864,8 @@ class PictureItem(FloatingItem):
             ):
                 return default_response
 
-            if (
-                isinstance(self.image.uri, AnyUrl) and self.image.uri.scheme == "file"
-            ) or isinstance(self.image.uri, Path):
-                img_text = f'<img src="{str(self.image.uri)}">'
-                return f"<figure>{caption_text}{img_text}</figure>"
-
-            else:
-                return default_response
+            img_text = f'<img src="{str(self.image.uri)}">'
+            return f"<figure>{caption_text}{img_text}</figure>"
 
         else:
             return default_response

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -810,14 +810,8 @@ class PictureItem(FloatingItem):
             ):
                 return default_response
 
-            if (
-                isinstance(self.image.uri, AnyUrl) and self.image.uri.scheme == "file"
-            ) or isinstance(self.image.uri, Path):
-                text = f"\n![Image]({str(self.image.uri)})\n"
-                return text
-
-            else:
-                return default_response
+            text = f"\n![Image]({str(self.image.uri)})\n"
+            return text
 
         else:
             return default_response


### PR DESCRIPTION
This changes impact only the case when a backend (or some user manipulation) defined an image with a remote url. It should be perfectly fine to return it in the exported html and markdown.

Refs: https://github.com/DS4SD/docling/discussions/477
