### PR TITLE
Bug: Support XLSX Mimetype

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -382,6 +382,7 @@ class DocumentOrigin(BaseModel):
         "application/vnd.openxmlformats-officedocument.presentationml.presentation",
         "text/asciidoc",
         "text/markdown",
+        "application/vnd.openxmlformats-officedocument.spreadsheet.ml.sheet"
     ]
 
     @field_validator("binary_hash", mode="before")

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -380,9 +380,9 @@ class DocumentOrigin(BaseModel):
         "application/vnd.openxmlformats-officedocument.presentationml.template",
         "application/vnd.openxmlformats-officedocument.presentationml.slideshow",
         "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         "text/asciidoc",
         "text/markdown",
-        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
     ]
 
     @field_validator("binary_hash", mode="before")

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -382,7 +382,7 @@ class DocumentOrigin(BaseModel):
         "application/vnd.openxmlformats-officedocument.presentationml.presentation",
         "text/asciidoc",
         "text/markdown",
-        "application/vnd.openxmlformats-officedocument.spreadsheet.ml.sheet"
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
     ]
 
     @field_validator("binary_hash", mode="before")


### PR DESCRIPTION
### Context
Using latest docling-core (v2.6.1) and docling (v2.8.1) xlsx files are unable to be processed due to a ValueError mentioning that the mimetype `"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"` is not valid as per DocumentOrigin

`"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"` is not a mimetype offered by default by the `mimetype` pkg being used by docling and hence has to be added in the extras section

### Fix
Add the mimetype as an extra mimetype
