### PR TITLE
fix(markdown): preserve underscores in image URLs during markdown export

### DIFF
--- a/test/data/doc/constructed_doc.referenced.md.gt
+++ b/test/data/doc/constructed_doc.referenced.md.gt
@@ -31,4 +31,4 @@ This is the caption of figure 1.
 
 This is the caption of figure 2.
 
-![Image](constructed\_images/image\_000001\_ccb4cbe7039fe17892f3d611cfb71eafff1d4d230b19b10779334cc4b63c98bc.png)
+![Image](constructed_images/image_000001_ccb4cbe7039fe17892f3d611cfb71eafff1d4d230b19b10779334cc4b63c98bc.png)

--- a/test/test_docling_doc.py
+++ b/test/test_docling_doc.py
@@ -670,7 +670,6 @@ def _normalise_string_wrt_filepaths(instr: str, paths: List[Path]):
 
     for p in paths:
         instr = instr.replace(str(p), str(p.name))
-        instr = instr.replace(str(p).replace("_", "\\_"), str(p.name))
 
     return instr
 


### PR DESCRIPTION
Solved the problem in this issue(#97)

Previously, all underscores in markdown output were escaped to prevent emphasis styling, which broke image URLs containing underscores. This fix modifies the underscore escaping logic to:

- Identify image URL patterns in markdown text
- Skip underscore escaping within image URL sections
- Continue escaping underscores in regular text content