### PR TITLE
feat: added the new label comment_section in the groups

### DIFF
--- a/docling_core/types/doc/labels.py
+++ b/docling_core/types/doc/labels.py
@@ -48,7 +48,8 @@ class GroupLabel(str, Enum):
     SLIDE = "slide"
     FORM_AREA = "form_area"
     KEY_VALUE_AREA = "key_value_area"
-
+    COMMENT_SECTION = "comment_section"
+    
     def __str__(self):
         """Get string value."""
         return str(self.value)

--- a/docling_core/types/doc/labels.py
+++ b/docling_core/types/doc/labels.py
@@ -49,7 +49,7 @@ class GroupLabel(str, Enum):
     FORM_AREA = "form_area"
     KEY_VALUE_AREA = "key_value_area"
     COMMENT_SECTION = "comment_section"
-    
+
     def __str__(self):
         """Get string value."""
         return str(self.value)

--- a/docs/DoclingDocument.json
+++ b/docs/DoclingDocument.json
@@ -266,7 +266,8 @@
         "sheet",
         "slide",
         "form_area",
-        "key_value_area"
+        "key_value_area",
+        "comment_section"
       ],
       "title": "GroupLabel",
       "type": "string"


### PR DESCRIPTION
To address comments and hidden text, we add a new group:

1. Things like slide comments, Word review comments, etc. should go into the furniture root and be put inside a group with new GroupLabel.COMMENT_SECTION
2. Optional: We can extend the type hierachy with a CommentItem, which additionally stores an author name and timestamp with the text.
3. We must add filter argument for group labels on the export functions (additional to DocItemLabels)