### PR TITLE
chore: annotate `**kwargs` in `HybridChunker.chunk`

### DIFF
--- a/docling_core/transforms/chunker/base.py
+++ b/docling_core/transforms/chunker/base.py
@@ -51,7 +51,7 @@ class BaseChunker(BaseModel, ABC):
     delim: str = DFLT_DELIM
 
     @abstractmethod
-    def chunk(self, dl_doc: DLDocument, **kwargs) -> Iterator[BaseChunk]:
+    def chunk(self, dl_doc: DLDocument, **kwargs: Any) -> Iterator[BaseChunk]:
         """Chunk the provided document.
 
         Args:

--- a/docling_core/transforms/chunker/hybrid_chunker.py
+++ b/docling_core/transforms/chunker/hybrid_chunker.py
@@ -6,7 +6,7 @@
 """Hybrid chunker implementation leveraging both doc structure & token awareness."""
 
 import warnings
-from typing import Iterable, Iterator, Optional, Union
+from typing import Any, Iterable, Iterator, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, PositiveInt, TypeAdapter, model_validator
 from typing_extensions import Self
@@ -258,7 +258,7 @@ class HybridChunker(BaseChunker):
 
         return output_chunks
 
-    def chunk(self, dl_doc: DoclingDocument, **kwargs) -> Iterator[BaseChunk]:
+    def chunk(self, dl_doc: DoclingDocument, **kwargs: Any) -> Iterator[BaseChunk]:
         r"""Chunk the provided document.
 
         Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,7 @@ module = [
     "jsonref.*",
     "jsonschema.*",
     "requests.*",
+    "semchunk.*",
     "tabulate.*",
     "transformers.*",
     "yaml.*",


### PR DESCRIPTION
strict pyright forbids calling this function with missing annotation