### PR TITLE
feat: add escaping_underscores option to markdown export

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -1994,6 +1994,7 @@ class DoclingDocument(BaseModel):
         to_element: int = sys.maxsize,
         labels: set[DocItemLabel] = DEFAULT_EXPORT_LABELS,
         strict_text: bool = False,
+        escaping_underscores: bool = True,
         image_placeholder: str = "<!-- image -->",
         image_mode: ImageRefMode = ImageRefMode.PLACEHOLDER,
         indent: int = 4,
@@ -2016,6 +2017,7 @@ class DoclingDocument(BaseModel):
             to_element=to_element,
             labels=labels,
             strict_text=strict_text,
+            escaping_underscores=escaping_underscores,
             image_placeholder=image_placeholder,
             image_mode=image_mode,
             indent=indent,
@@ -2033,6 +2035,7 @@ class DoclingDocument(BaseModel):
         to_element: int = sys.maxsize,
         labels: set[DocItemLabel] = DEFAULT_EXPORT_LABELS,
         strict_text: bool = False,
+        escaping_underscores: bool = True,
         image_placeholder: str = "<!-- image -->",
         image_mode: ImageRefMode = ImageRefMode.PLACEHOLDER,
         indent: int = 4,
@@ -2058,6 +2061,9 @@ class DoclingDocument(BaseModel):
         :param strict_text: bool: Whether to only include the text content
             of the document. (Default value = False).
         :type strict_text: bool = False
+        :param escaping_underscores: bool: Whether to escape underscores in the
+            text content of the document. (Default value = True).
+        :type escaping_underscores: bool = True
         :param image_placeholder: The placeholder to include to position
             images in the markdown. (Default value = "\<!-- image --\>").
         :type image_placeholder: str = "<!-- image -->"
@@ -2226,7 +2232,8 @@ class DoclingDocument(BaseModel):
 
             return "".join(parts)
 
-        mdtext = escape_underscores(mdtext)
+        if escaping_underscores:
+            mdtext = escape_underscores(mdtext)
 
         return mdtext
 
@@ -2244,6 +2251,7 @@ class DoclingDocument(BaseModel):
             to_element,
             labels,
             strict_text=True,
+            escaping_underscores=False,
             image_placeholder="",
         )
 


### PR DESCRIPTION
BREAKING CHANGE: export to text no longer escapes underscores.

Add `escaping_underscores` option to `export_to_markdown(). 
Set default value to `escaping_underscores` to True.

resolves #134 