### PR TITLE
fix: Add newline to formula md export

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -2229,9 +2229,7 @@ class DoclingDocument(BaseModel):
 
             return "".join(parts)
 
-        print("BEFORE:", mdtext)
         mdtext = escape_underscores(mdtext)
-        print("AFTER:", mdtext)
 
         return mdtext
 

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -2160,6 +2160,10 @@ class DoclingDocument(BaseModel):
                 text = f"{list_indent}{marker} {item.text}"
                 mdtexts.append(text)
 
+            elif isinstance(item, TextItem) and item.label in [DocItemLabel.FORMULA]:
+                in_list = False
+                mdtexts.append(f"$${item.text}$$")
+
             elif isinstance(item, TextItem) and item.label in labels:
                 in_list = False
                 if len(item.text) and text_width > 0:

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -2208,7 +2208,8 @@ class DoclingDocument(BaseModel):
             """Escape underscores but leave them intact in the URL.."""
             # Firstly, identify all the URL patterns.
             url_pattern = r"!\[.*?\]\((.*?)\)"
-            latex_pattern = r"\$(?:\\.|[^$\\])*\$"
+            # Matches both inline ($...$) and block ($$...$$) LaTeX equations:
+            latex_pattern = r"\$\$?(?:\\.|[^$\\])*\$\$?"
             combined_pattern = f"({url_pattern})|({latex_pattern})"
 
             parts = []

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -2162,7 +2162,7 @@ class DoclingDocument(BaseModel):
 
             elif isinstance(item, TextItem) and item.label in [DocItemLabel.FORMULA]:
                 in_list = False
-                mdtexts.append(f"$${item.text}$$")
+                mdtexts.append(f"$${item.text}$$\n")
 
             elif isinstance(item, TextItem) and item.label in labels:
                 in_list = False

--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -2208,10 +2208,13 @@ class DoclingDocument(BaseModel):
             """Escape underscores but leave them intact in the URL.."""
             # Firstly, identify all the URL patterns.
             url_pattern = r"!\[.*?\]\((.*?)\)"
+            latex_pattern = r"\$(?:\\.|[^$\\])*\$"
+            combined_pattern = f"({url_pattern})|({latex_pattern})"
+
             parts = []
             last_end = 0
 
-            for match in re.finditer(url_pattern, text):
+            for match in re.finditer(combined_pattern, text):
                 # Text to add before the URL (needs to be escaped)
                 before_url = text[last_end : match.start()]
                 parts.append(re.sub(r"(?<!\\)_", r"\_", before_url))
@@ -2226,7 +2229,9 @@ class DoclingDocument(BaseModel):
 
             return "".join(parts)
 
+        print("BEFORE:", mdtext)
         mdtext = escape_underscores(mdtext)
+        print("AFTER:", mdtext)
 
         return mdtext
 


### PR DESCRIPTION
Adding new line to the end of standalone formula exports for markdown.