### PR TITLE
fix: Document Tokens (DocTag) clean up

### DIFF
--- a/docling_core/types/doc/tokens.py
+++ b/docling_core/types/doc/tokens.py
@@ -44,75 +44,20 @@ class TableToken(Enum):
 class DocumentToken(Enum):
     """Class to represent an LLM friendly representation of a Document."""
 
-    BEG_DOCUMENT = "<doctag>"
-    END_DOCUMENT = "</doctag>"
-
-    BEG_TITLE = "<title>"
-    END_TITLE = "</title>"
-
-    BEG_ABSTRACT = "<abstract>"
-    END_ABSTRACT = "</abstract>"
-
-    BEG_DOI = "<doi>"
-    END_DOI = "</doi>"
-    BEG_DATE = "<date>"
-    END_DATE = "</date>"
-
-    BEG_AUTHORS = "<authors>"
-    END_AUTHORS = "</authors>"
-    BEG_AUTHOR = "<author>"
-    END_AUTHOR = "</author>"
-
-    BEG_AFFILIATIONS = "<affiliations>"
-    END_AFFILIATIONS = "</affiliations>"
-    BEG_AFFILIATION = "<affiliation>"
-    END_AFFILIATION = "</affiliation>"
-    BEG_TEXT = "<text>"
-    END_TEXT = "</text>"
-    BEG_PARAGRAPH = "<paragraph>"
-    END_PARAGRAPH = "</paragraph>"
-    BEG_TABLE = "<table>"
-    END_TABLE = "</table>"
-    BEG_OTSL = "<otsl>"
-    END_OTSL = "</otsl>"
-    BEG_PICTURE = "<picture>"
-    END_PICTURE = "</picture>"
-    BEG_CAPTION = "<caption>"
-    END_CAPTION = "</caption>"
-    BEG_EQUATION = "<formula>"
-    END_EQUATION = "</formula>"
-    BEG_CODE = "<code>"
-    END_CODE = "</code>"
-    BEG_LIST = "<list>"
-    END_LIST = "</list>"
-    BEG_LISTITEM = "<list-item>"
-    END_LISTITEM = "</list-item>"
-    BEG_LINE_NUMBER = "<line_number>"
-    END_LINE_NUMBER = "</line_number>"
-    BEG_LOCATION = "<location>"
-    END_LOCATION = "</location>"
-    BEG_GROUP = "<group>"
-    END_GROUP = "</group>"
-
-    PAGE_BREAK = "<page_break>"
+    DOCUMENT = "doctag"
+    OTSL = "otsl"
+    ORDERED_LIST = "ordered_list"
+    UNORDERED_LIST = "unordered_list"
+    LOC = "loc_"
+    PAGE_BREAK = "page_break"
 
     @classmethod
     def get_special_tokens(
         cls,
-        max_rows: int = 100,
-        max_cols: int = 100,
-        max_pages: int = 1000,
         page_dimension: Tuple[int, int] = (100, 100),
     ):
         """Function to get all special document tokens."""
         special_tokens = [token.value for token in cls]
-
-        # Adding dynamically generated row and col tokens
-        for i in range(0, max_rows + 1):
-            special_tokens += [f"<row_{i}>", f"</row_{i}>"]
-
-        for i in range(0, max_cols + 1):
-            special_tokens += [f"<col_{i}>", f"</col_{i}>"]
 
         for i in range(6):
             special_tokens += [
@@ -134,22 +79,6 @@ class DocumentToken(Enum):
     def is_known_token(label):
         """Function to check if label is in tokens."""
         return label in DocumentToken.get_special_tokens()
-
-    @staticmethod
-    def get_row_token(row: int, beg=bool) -> str:
-        """Function to get page tokens."""
-        if beg:
-            return f"<row_{row}>"
-        else:
-            return f"</row_{row}>"
-
-    @staticmethod
-    def get_col_token(col: int, beg=bool) -> str:
-        """Function to get page tokens."""
-        if beg:
-            return f"<col_{col}>"
-        else:
-            return f"</col_{col}>"
 
     @staticmethod
     def get_picture_classification_token(classification: str) -> str:

--- a/docs/DoclingDocument.json
+++ b/docs/DoclingDocument.json
@@ -208,6 +208,14 @@
           "title": "Prov",
           "type": "array"
         },
+        "orig": {
+          "title": "Orig",
+          "type": "string"
+        },
+        "text": {
+          "title": "Text",
+          "type": "string"
+        },
         "captions": {
           "default": [],
           "items": {
@@ -242,14 +250,6 @@
             }
           ],
           "default": null
-        },
-        "orig": {
-          "title": "Orig",
-          "type": "string"
-        },
-        "text": {
-          "title": "Text",
-          "type": "string"
         },
         "code_language": {
           "$ref": "#/$defs/CodeLanguageLabel",


### PR DESCRIPTION
Clean up removing unnused tags at the moment, reliance mainly on DocItemLabel and DocumentTokens when unavoidable.