### PR TITLE
fix(markdown): fix handling of ordered lists

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -2489,11 +2489,16 @@ class DoclingDocument(BaseModel):
                     )
                     # NOTE: assumes unordered (flag & marker currently in ListItem)
                     indent_str = list_level * indent * " "
+                    is_ol = item.label == GroupLabel.ORDERED_LIST
                     text = "\n".join(
                         [
                             # avoid additional marker on already evaled sublists
-                            cpt if cpt and cpt[0] == " " else f"{indent_str}- {cpt}"
-                            for cpt in comps
+                            (
+                                c
+                                if c and c[0] == " "
+                                else f"{indent_str}{f'{i + 1}.' if is_ol else '-'} {c}"
+                            )
+                            for i, c in enumerate(comps)
                         ]
                     )
                     _ingest_text(text=text)

--- a/test/data/doc/constructed_doc.embedded.md.gt
+++ b/test/data/doc/constructed_doc.embedded.md.gt
@@ -15,10 +15,10 @@ This paper introduces the biggest invention ever made. ...
 - list item 1
 - list item 2
 - list item 3
-    - list item 3.a
-    - list item 3.b
-    - list item 3.c
-        - list item 3.c.i
+    1. list item 3.a
+    2. list item 3.b
+    3. list item 3.c
+        1. list item 3.c.i
 - list item 4
 
 This is the caption of table 1.

--- a/test/data/doc/constructed_doc.placeholder.md.gt
+++ b/test/data/doc/constructed_doc.placeholder.md.gt
@@ -15,10 +15,10 @@ This paper introduces the biggest invention ever made. ...
 - list item 1
 - list item 2
 - list item 3
-    - list item 3.a
-    - list item 3.b
-    - list item 3.c
-        - list item 3.c.i
+    1. list item 3.a
+    2. list item 3.b
+    3. list item 3.c
+        1. list item 3.c.i
 - list item 4
 
 This is the caption of table 1.

--- a/test/data/doc/constructed_doc.referenced.md.gt
+++ b/test/data/doc/constructed_doc.referenced.md.gt
@@ -15,10 +15,10 @@ This paper introduces the biggest invention ever made. ...
 - list item 1
 - list item 2
 - list item 3
-    - list item 3.a
-    - list item 3.b
-    - list item 3.c
-        - list item 3.c.i
+    1. list item 3.a
+    2. list item 3.b
+    3. list item 3.c
+        1. list item 3.c.i
 - list item 4
 
 This is the caption of table 1.

--- a/test/data/doc/constructed_document.yaml.md
+++ b/test/data/doc/constructed_document.yaml.md
@@ -15,10 +15,10 @@ This paper introduces the biggest invention ever made. ...
 - list item 1
 - list item 2
 - list item 3
-    - list item 3.a
-    - list item 3.b
-    - list item 3.c
-        - list item 3.c.i
+    1. list item 3.a
+    2. list item 3.b
+    3. list item 3.c
+        1. list item 3.c.i
 - list item 4
 
 This is the caption of table 1.


### PR DESCRIPTION
For now only covers basic ordered lists, i.e. starting from 1.

Special cases (different starting number, different symbols (e.g. latin) etc.) to be addressed separately as it may require minor reworking of the data model (e.g. adding some metadata to the GroupItem that represents an ordered list).