### PR TITLE
chore: use GH cache for HF models

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,6 +1,10 @@
 on:
   workflow_call:
 
+env:
+  HF_HUB_DOWNLOAD_TIMEOUT: "60"
+  HF_HUB_ETAG_TIMEOUT: "60"
+
 jobs:
   run-checks:
     runs-on: ubuntu-latest
@@ -8,7 +12,12 @@ jobs:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - name: Cache Hugging Face models
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          key: huggingface-cache-py${{ matrix.python-version }}
       - uses: ./.github/actions/setup-poetry
         with:
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
Porting https://github.com/DS4SD/docling/pull/1096 to docling-core as similar issues occur when using HuggingFace embedding models (e.g. for `HybridChunker` tests).