### PR TITLE
fix: suppress warning for missing fallback case

### DIFF
--- a/docling_core/types/doc/document.py
+++ b/docling_core/types/doc/document.py
@@ -2848,7 +2848,7 @@ class DoclingDocument(BaseModel):
 
                 # Building a math equation in MathML format
                 # ref https://www.w3.org/TR/wai-aria-1.1/#math
-                elif formula_to_mathml:
+                elif formula_to_mathml and len(math_formula) > 0:
                     try:
                         mathml_element = latex2mathml.converter.convert_to_element(
                             math_formula, display="block"
@@ -2870,7 +2870,7 @@ class DoclingDocument(BaseModel):
                             and img_fallback is not None
                         ):
                             text = img_fallback
-                        elif len(math_formula) > 0:
+                        else:
                             text = f"<pre>{math_formula}</pre>"
 
                 elif math_formula != "":


### PR DESCRIPTION
https://github.com/DS4SD/docling-core/pull/166 newly routed cases for formulas with empty text and missing fallback into the try-except block resulting in excessive warning log entries. Those passed through the if-elif clause with only the logging side effect. Change it so that they bypass the clause without visiting the elif case, thus avoiding the logging.